### PR TITLE
Move CPU history chart to the top of the sidebar

### DIFF
--- a/src/content/sidebar.css
+++ b/src/content/sidebar.css
@@ -73,6 +73,41 @@ td:last-child {
   text-overflow: ellipsis;
 }
 
+#history {
+  border: 1px solid rgb(204, 204, 204);
+  background-color: #fff;
+}
+
+#history h1 {
+  margin: 5px 0;
+  text-align: center;
+  text-transform: uppercase;
+  color: #666;
+  font-size: 0.7em;
+}
+
+#history hr {
+  margin: 0 10px 2px;
+}
+
+#history-chart {
+  width: 100%;
+  height: 70px;
+  padding: 0 2px;
+}
+
+#history-chart #chart-kernel-cpu {
+  stroke: #d90074;
+  stroke-width: 1px;
+  fill: none;
+}
+
+#history-chart #chart-user-cpu {
+  stroke: #0074d9;
+  stroke-width: 1px;
+  fill: none;
+}
+
 /* Take scrollbar width into account for aligning 'Memory'  */
 #processes-table thead td:nth-child(4) {
   width: 95px;
@@ -80,7 +115,7 @@ td:last-child {
 }
 
 #processes-table tbody {
-  height: 55vh;
+  height: 54vh;
 }
 
 #processes-table td:nth-child(1) {
@@ -111,7 +146,7 @@ td:last-child {
 }
 
 #pages-table tbody {
-  height: 29vh;
+  height: 20vh;
 }
 
 #pages-table td:nth-child(1) {
@@ -137,7 +172,7 @@ td:last-child {
 }
 
 #threads-table tbody {
-  height: 29vh;
+  height: 20vh;
 }
 
 #threads-table td:nth-child(1) {
@@ -196,26 +231,6 @@ td:last-child {
 
 #details {
   font-size: 0.8em;
-}
-
-#details #history-chart {
-  width: 100%;
-  height: 100px;
-  border: 1px solid rgb(204, 204, 204);
-  padding: 0 2px;
-  background-color: white;
-}
-
-#chart-kernel-cpu {
-  stroke: #d90074;
-  stroke-width: 1px;
-  fill: none;
-}
-
-#chart-user-cpu {
-  stroke: #0074d9;
-  stroke-width: 1px;
-  fill: none;
 }
 
 #details-left p {

--- a/src/content/sidebar.html
+++ b/src/content/sidebar.html
@@ -10,6 +10,15 @@
 
   <body>
     <div id="sidebar-content">
+      <div id="history">
+        <h1>cpu load</h1>
+        <hr/>
+        <svg xmlns="http://www.w3.org/2000/svg" id="history-chart">
+          <polyline id="chart-kernel-cpu" />
+          <polyline id="chart-user-cpu" />
+        </svg>
+      </div>
+
       <table id="processes-table">
         <thead>
           <tr>
@@ -29,10 +38,6 @@
         </div>
 
         <div id="details" class="tabcontent" active="true">
-          <svg xmlns="http://www.w3.org/2000/svg" id="history-chart">
-            <polyline id="chart-kernel-cpu"/>
-            <polyline id="chart-user-cpu"/>
-          </svg>
           <div id="details-left">
             <p>User:<span id="cpu-user"></span></p>
             <p>System: <span id="cpu-kernel"></span></p>


### PR DESCRIPTION
It allows to always have the CPU history chart visible, independently of which details pane is actually selected.