### PR TITLE
Use document's URI instead of title to better identify windows

### DIFF
--- a/src/content/sidebar.js
+++ b/src/content/sidebar.js
@@ -200,7 +200,7 @@ function updatePagesView() {
       content.appendChild(row);
     }
 
-    url.firstChild.data = page.documentTitle || page.documentURI;
+    url.firstChild.data = page.documentURI;
     type.firstChild.data = page.type;
   });
 


### PR DESCRIPTION
Having only the title visible in the pages pane isn't particular helpful to identify problematic URIs as mostly used for ads. Showing the URI instead gives way more information.