### PR TITLE
Make use of performance improvements when collecting memory information

### DIFF
--- a/src/content/background.js
+++ b/src/content/background.js
@@ -114,6 +114,13 @@ class TaskManager extends Object {
         process.currentCpu = 0;
       }
 
+      // Starting with Firefox 94 the memory property improves performance
+      // when retrieving used memory. For older releases keep backward
+      // compatibility.
+      if (typeof(process.memory) == "undefined") {
+        process.memory = process.residentMemory;
+      }
+
       process.threads = process.threads.map(thread => {
         const previousThread =
           previousProcess?.threads.find(t => t.tid == thread.tid);

--- a/src/content/sidebar.js
+++ b/src/content/sidebar.js
@@ -122,10 +122,10 @@ function updateProcessesView() {
     pid.firstChild.data = process.pid;
     cpu.firstChild.data = process.currentCpu.toFixed(1);
 
-    if (process.residentMemory > BYTES_TO_GIGABYTE) {
-      memory.firstChild.data = `${(process.residentMemory / BYTES_TO_GIGABYTE).toFixed(1)} GB`;
+    if (process.memory > BYTES_TO_GIGABYTE) {
+      memory.firstChild.data = `${(process.memory / BYTES_TO_GIGABYTE).toFixed(1)} GB`;
     } else {
-      memory.firstChild.data = `${(process.residentMemory / BYTES_TO_MEGABYTE).toFixed(1)} MB`;
+      memory.firstChild.data = `${(process.memory / BYTES_TO_MEGABYTE).toFixed(1)} MB`;
     }
 
     // Assume that if no processes are listed for the active tab it runs in
@@ -279,7 +279,7 @@ function sortProcesses(processes) {
       case "cpu":
         return a.currentCpu - b.currentCpu;
       case "memory":
-        return a.residentMemory - b.residentMemory;
+        return a.memory - b.memory;
     }
   });
 


### PR DESCRIPTION
With this patch the extension will make use of the recent [performance improvements when retrieving memory usage](https://bugzilla.mozilla.org/show_bug.cgi?id=1665318).